### PR TITLE
Update deprecated function in ue 5.5

### DIFF
--- a/Source/TriangleShaderModule/Private/TriangleShaderModule.cpp
+++ b/Source/TriangleShaderModule/Private/TriangleShaderModule.cpp
@@ -1,10 +1,10 @@
 #include "TriangleShaderModule.h"
 
-void FTriangleShaderModule::StartupModule()
-{
-	FString PluginBaseDirectory = IPluginManager::Get().FindPlugin(TEXT("TriangleShaderModule"))->GetBaseDir();
-	FString PluginShaderDirectory = FPaths::Combine(PluginBaseDirectory, TEXT("Shaders"));
-	AddShaderSourceDirectoryMapping(TEXT("/TriangleShaderModule"), PluginShaderDirectory);
+void FTriangleShaderModule::StartupModule(){
+	
+	FString BaseDir = FPaths::Combine(FPaths::GameSourceDir(), TEXT("TriangleShaderModule"));
+	FString ModuleShaderDir = FPaths::Combine(BaseDir, TEXT("Shaders"));
+	AddShaderSourceDirectoryMapping(TEXT("/TriangleShaderModule"), ModuleShaderDir);
 }
 
 void FTriangleShaderModule::ShutdownModule()

--- a/Source/TriangleShaderModule/Private/TriangleShaderModule.cpp
+++ b/Source/TriangleShaderModule/Private/TriangleShaderModule.cpp
@@ -1,10 +1,10 @@
 #include "TriangleShaderModule.h"
 
-void FTriangleShaderModule::StartupModule(){
-	
-	FString BaseDir = FPaths::Combine(FPaths::GameSourceDir(), TEXT("TriangleShaderModule"));
-	FString ModuleShaderDir = FPaths::Combine(BaseDir, TEXT("Shaders"));
-	AddShaderSourceDirectoryMapping(TEXT("/TriangleShaderModule"), ModuleShaderDir);
+void FTriangleShaderModule::StartupModule()
+{
+	FString PluginBaseDirectory = IPluginManager::Get().FindPlugin(TEXT("TriangleShaderModule"))->GetBaseDir();
+	FString PluginShaderDirectory = FPaths::Combine(PluginBaseDirectory, TEXT("Shaders"));
+	AddShaderSourceDirectoryMapping(TEXT("/TriangleShaderModule"), PluginShaderDirectory);
 }
 
 void FTriangleShaderModule::ShutdownModule()

--- a/Source/TriangleShaderModule/Private/TriangleViewExtension.cpp
+++ b/Source/TriangleShaderModule/Private/TriangleViewExtension.cpp
@@ -41,6 +41,7 @@ FScreenPassTextureViewportParameters GetTextureViewportParameters(const FScreenP
 
 	return Parameters;
 }
+
 FSceneTextureParameters GetSceneTextureParameters(FRDGBuilder& GraphBuilder, const FSceneTextures& SceneTextures)
 {
 	const auto& SystemTextures = FRDGSystemTextures::Get(GraphBuilder);
@@ -63,6 +64,7 @@ FSceneTextureParameters GetSceneTextureParameters(FRDGBuilder& GraphBuilder, con
 
 	return Parameters;
 }
+
 FVector2f GetInputViewportSize2f(const FIntRect& Input, const FIntPoint& Extent)
 {
 	// Based on
@@ -92,7 +94,7 @@ void FTriangleViewExtension::PreRenderView_RenderThread(FRDGBuilder& GraphBuilde
 		
 }
 
-void FTriangleViewExtension::SubscribeToPostProcessingPass(EPostProcessingPass Pass, FAfterPassCallbackDelegateArray& InOutPassCallbacks, bool bIsPassEnabled)
+void FTriangleViewExtension::SubscribeToPostProcessingPass(EPostProcessingPass Pass, const FSceneView& InView, FAfterPassCallbackDelegateArray& InOutPassCallbacks, bool bIsPassEnabled)
 {
 	if (Pass == EPostProcessingPass::Tonemap)
 	{

--- a/Source/TriangleShaderModule/Public/TriangleViewExtension.h
+++ b/Source/TriangleShaderModule/Public/TriangleViewExtension.h
@@ -16,8 +16,8 @@ public:
 	virtual void PreRenderView_RenderThread(FRDGBuilder& GraphBuilder, FSceneView& InView) override;
 	virtual void PostRenderBasePass_RenderThread(FRHICommandListImmediate& RHICmdList, FSceneView& InView) override {};
 	virtual void PrePostProcessPass_RenderThread(FRDGBuilder& GraphBuilder, const FSceneView& View, const FPostProcessingInputs& Inputs) override;
+	virtual void SubscribeToPostProcessingPass(EPostProcessingPass Pass, const FSceneView& InView, FAfterPassCallbackDelegateArray& InOutPassCallbacks, bool bIsPassEnabled) override;
 	//~ End FSceneViewExtensionBase Interface
-	virtual void SubscribeToPostProcessingPass(EPostProcessingPass Pass, FAfterPassCallbackDelegateArray& InOutPassCallbacks, bool bIsPassEnabled) override;
 
 protected:
 


### PR DESCRIPTION
In Unreal Enigne 5.5, function "SubscribeToPostProcessingPass" has been deprecated.
I updated it newer version.

And there are other commits. they are for the coreect paths for connection with shader.
For success to compile in unreal engine project, it should be replaced.
But as in only in this repositery, Keeping the status quo is the right approach.
So, you could ignore them.